### PR TITLE
Check for Minecraft 1.21.4 before Pale Garden code

### DIFF
--- a/shaders/entity.properties
+++ b/shaders/entity.properties
@@ -16,6 +16,6 @@ entity.106=minecraft:end_crystal
 entity.106=minecraft:ender_crystal
 #endif
 
-#if MC_VERSION >= 12100
+#if MC_VERSION >= 12104
 entity.107=creaking
 #endif

--- a/shaders/lib/atmosphere/fog.glsl
+++ b/shaders/lib/atmosphere/fog.glsl
@@ -44,7 +44,7 @@ void getNormalFog(inout vec3 color, vec3 viewPos, in vec3 worldPos, in vec3 atmo
 	float fogDistance = min(192.0 / dhFarPlane, 1.0) * (100.0 / distanceFactor);
 	float fogDensity = FOG_DENSITY * (2.0 - caveFactor) * (1.0 - eBS01 * timeBrightness * 0.5);
 
-	#if MC_VERSION >= 12100
+	#if MC_VERSION >= 12104
 	fogDensity = mix(fogDensity, 6.0, isPaleGarden);
 	fogDistance *= 1.0 - isPaleGarden * 0.75;
 	#endif
@@ -108,7 +108,7 @@ void getNormalFog(inout vec3 color, vec3 viewPos, in vec3 worldPos, in vec3 atmo
 	#ifndef NETHER
 	#ifdef DEFERRED
 	float zMixer = float(texture2D(dhDepthTex0, texCoord).r < 1.0);
-	#if MC_VERSION >= 12100
+	#if MC_VERSION >= 12104
 		  zMixer = mix(zMixer, 1.0, isPaleGarden);
 	#endif
 	#ifdef FOG_COVER_EVERYTHING
@@ -135,7 +135,7 @@ void getNormalFog(inout vec3 color, vec3 viewPos, in vec3 worldPos, in vec3 atmo
 	float fogDistance = min(192.0 / far, 1.0) * (100.0 / distanceFactor);
 	float fogDensity = FOG_DENSITY * (2.0 - caveFactor) * (1.0 - eBS01 * timeBrightness * 0.5);
 
-	#if MC_VERSION >= 12100
+	#if MC_VERSION >= 12104
 	fogDensity = mix(fogDensity, 6.0, isPaleGarden);
 	fogDistance *= 1.0 - isPaleGarden * 0.75;
 	#endif
@@ -199,7 +199,7 @@ void getNormalFog(inout vec3 color, vec3 viewPos, in vec3 worldPos, in vec3 atmo
 	#ifndef NETHER
 	#ifdef DEFERRED
 	float zMixer = float(texture2D(depthtex1, texCoord).r < 1.0);
-	#if MC_VERSION >= 12100
+	#if MC_VERSION >= 12104
 		  zMixer = mix(zMixer, 1.0, isPaleGarden);
 	#endif
 	#ifdef FOG_COVER_EVERYTHING

--- a/shaders/lib/atmosphere/volumetricClouds.glsl
+++ b/shaders/lib/atmosphere/volumetricClouds.glsl
@@ -181,7 +181,7 @@ void computeVolumetricClouds(inout vec4 vc, in vec3 atmosphereColor, float z1, f
 
 			float opacity = clamp(mix(0.99, VC_OPACITY, float(z1 == 1.0 && cameraPosition.y < VC_HEIGHT)), 0.0, 1.0 - wetness * 0.5);
 
-			#if MC_VERSION >= 12100
+			#if MC_VERSION >= 12104
 			opacity = mix(opacity, opacity * 0.5, isPaleGarden);
 			#endif
 

--- a/shaders/lib/atmosphere/volumetricLight.glsl
+++ b/shaders/lib/atmosphere/volumetricLight.glsl
@@ -18,7 +18,7 @@ void computeVL(inout vec3 vl, in vec3 translucent, in float dither) {
 
     //Total Visibility & Variables
     float indoorFactor = (1.0 - eBS * eBS) * float(isEyeInWater == 0 && cameraPosition.y < 1000.0);
-		#if MC_VERSION >= 12100
+		#if MC_VERSION >= 12104
 		indoorFactor = mix(indoorFactor, 1.0, isPaleGarden * 0.5);
 		#endif
 
@@ -58,7 +58,7 @@ void computeVL(inout vec3 vl, in vec3 translucent, in float dither) {
 		float maxDist = min(shadowDistance, 256.0);
 		float minDist = (maxDist / sampleCount) * 0.6;
 
-		#if MC_VERSION >= 12100
+		#if MC_VERSION >= 12104
 		minDist *= 1.0 - isPaleGarden * 0.5;
 		#endif
 

--- a/shaders/program/composite3.glsl
+++ b/shaders/program/composite3.glsl
@@ -25,7 +25,7 @@ uniform float blindFactor;
 uniform float timeAngle, shadowFade;
 uniform float isJungle, isSwamp;
 
-#if MC_VERSION >= 12100
+#if MC_VERSION >= 12104
 uniform float isPaleGarden;
 #endif
 

--- a/shaders/program/deferred2.glsl
+++ b/shaders/program/deferred2.glsl
@@ -27,7 +27,7 @@ uniform float isSnowy;
 uniform float darknessFactor;
 #endif
 
-#if MC_VERSION >= 12100
+#if MC_VERSION >= 12104
 uniform float isPaleGarden;
 #endif
 

--- a/shaders/program/gbuffers_textured.glsl
+++ b/shaders/program/gbuffers_textured.glsl
@@ -29,7 +29,7 @@ uniform float viewWidth, viewHeight;
 uniform float darknessFactor;
 #endif
 
-#if MC_VERSION >= 12100
+#if MC_VERSION >= 12104
 uniform float isPaleGarden;
 #endif
 

--- a/shaders/program/gbuffers_water.glsl
+++ b/shaders/program/gbuffers_water.glsl
@@ -32,7 +32,7 @@ uniform float viewWidth, viewHeight;
 uniform float darknessFactor;
 #endif
 
-#if MC_VERSION >= 12100
+#if MC_VERSION >= 12104
 uniform float isPaleGarden;
 #endif
 

--- a/shaders/shaders.properties
+++ b/shaders/shaders.properties
@@ -117,7 +117,9 @@ uniform.float.isSnowy=smooth(1, if(in(biome, BIOME_GROVE, BIOME_SNOWY_SLOPES, BI
                      smooth(13, if(in(biome, BIOME_OLD_GROWTH_SPRUCE_TAIGA), 1, 0) * yCold3, 10, 10)
 uniform.float.isSwamp=smooth(4, if(in(biome, BIOME_SWAMP, BIOME_MANGROVE_SWAMP), 1, 0), 10, 10)
 uniform.float.isJungle=smooth(7, if(in(biome, BIOME_JUNGLE, BIOME_SPARSE_JUNGLE, BIOME_BAMBOO_JUNGLE), 1, 0), 10, 10)
+#if MC_VERSION >= 12104
 uniform.float.isPaleGarden=smooth(54, if(in(biome, BIOME_PALE_GARDEN), 1, 0), 10, 10)
+#endif
 
 #TAA Jitter
 uniform.float.framemod8 = frameCounter % 8


### PR DESCRIPTION
With Minecraft 1.21.1 and Solas Shader V2.5, I've been getting the following errors in `launcher_log.txt`:

```java
[Info: 2024-12-31 15:23:05.2271277: /u9FIoBvBTc=: MinecraftJavaLoggingContext.cpp(65)] Game/Iris (Render thread) Warn Failed to resolve uniform isPaleGarden, reason: Unknown variable: BIOME_PALE_GARDEN ( = FunctionCall{smooth {[Number{54}, FunctionCall{if {[FunctionCall{in {[Id{biome}, Id{BIOME_PALE_GARDEN}]} }, Number{1}, Number{0}]} }, Number{10}, Number{10}]} })
java.lang.RuntimeException: Unknown variable: BIOME_PALE_GARDEN
	at kroppeb.stareval.resolver.ExpressionResolver.resolveExpressionInternal(ExpressionResolver.java:225)
	at kroppeb.stareval.resolver.ExpressionResolver.resolveCallExpressionInternal(ExpressionResolver.java:81)
	at kroppeb.stareval.resolver.ExpressionResolver.resolveCallExpression(ExpressionResolver.java:140)
	at kroppeb.stareval.resolver.ExpressionResolver.resolveExpressionInternal(ExpressionResolver.java:196)
	at kroppeb.stareval.resolver.ExpressionResolver.resolveCallExpressionInternal(ExpressionResolver.java:81)
	at kroppeb.stareval.resolver.ExpressionResolver.resolveCallExpression(ExpressionResolver.java:140)
	at kroppeb.stareval.resolver.ExpressionResolver.resolveCallExpression(ExpressionResolver.java:127)
	at kroppeb.stareval.resolver.ExpressionResolver.resolveExpressionInternal(ExpressionResolver.java:196)
	at kroppeb.stareval.resolver.ExpressionResolver.resolveCallExpressionInternal(ExpressionResolver.java:81)
	at kroppeb.stareval.resolver.ExpressionResolver.resolveCallExpression(ExpressionResolver.java:140)
	at kroppeb.stareval.resolver.ExpressionResolver.resolveExpressionInternal(ExpressionResolver.java:196)
	at kroppeb.stareval.resolver.ExpressionResolver.resolveExpression(ExpressionResolver.java:50)
	at net.irisshaders.iris.uniforms.custom.CustomUniforms.<init>(CustomUniforms.java:60)
	at net.irisshaders.iris.uniforms.custom.CustomUniforms$Builder.build(CustomUniforms.java:332)
	at net.irisshaders.iris.uniforms.custom.CustomUniforms$Builder.build(CustomUniforms.java:343)
	at net.irisshaders.iris.pipeline.IrisRenderingPipeline.<init>(IrisRenderingPipeline.java:277)
	at net.irisshaders.iris.Iris.createPipeline(Iris.java:616)
	at net.irisshaders.iris.pipeline.PipelineManager.preparePipeline(PipelineManager.java:33)
	at net.minecraft.class_310.handler$bge000$iris$resetPipeline(class_310.java:7702)
	at net.minecraft.class_310.method_18097(class_310.java)
	at net.minecraft.class_310.method_1481(class_310.java:2204)
	at net.minecraft.class_634.method_11120(class_634.java:430)
	at net.minecraft.class_2678.method_11567(class_2678.java:69)
	at net.minecraft.class_2678.method_11054(class_2678.java:17)
	at net.minecraft.class_2600.method_11072(class_2600.java:27)
	at net.minecraft.class_1255.method_18859(class_1255.java:162)
	at net.minecraft.class_4093.method_18859(class_4093.java:23)
	at net.minecraft.class_1255.method_16075(class_1255.java:136)
	at net.minecraft.class_1255.method_5383(class_1255.java:121)
	at net.minecraft.class_310.method_1523(class_310.java:1240)
	at net.minecraft.class_310.method_1514(class_310.java:882)
	at net.minecraft.client.main.Main.main(Main.java:256)
	at net.fabricmc.loader.impl.game.minecraft.MinecraftGameProvider.launch(MinecraftGameProvider.java:480)
	at net.fabricmc.loader.impl.launch.knot.Knot.launch(Knot.java:74)
	at net.fabricmc.loader.impl.launch.knot.KnotClient.main(KnotClient.java:23)

[Info: 2024-12-31 15:23:05.2869347: /u9FIoBvBTc=: MinecraftJavaLoggingContext.cpp(65)] Game/net.irisshaders.iris.gl.shader.GlShader (Render thread) Warn Shader compilation log for dh_water.fsh: 0(392) : error C1503: undefined variable "isPaleGarden"
0(393) : error C1503: undefined variable "isPaleGarden"

[Info: 2024-12-31 15:23:05.2885811: /u9FIoBvBTc=: MinecraftJavaLoggingContext.cpp(65)] Game/Iris (Render thread) Error Failed to create shader rendering pipeline, disabling shaders!
net.irisshaders.iris.gl.shader.ShaderCompileException: dh_water.fsh: dh_water.fsh: 0(392) : error C1503: undefined variable "isPaleGarden"
0(393) : error C1503: undefined variable "isPaleGarden"

	at net.irisshaders.iris.gl.shader.GlShader.createShader(GlShader.java:46)
	at net.irisshaders.iris.gl.shader.GlShader.<init>(GlShader.java:25)
	at net.irisshaders.iris.compat.dh.IrisLodRenderProgram.<init>(IrisLodRenderProgram.java:90)
	at net.irisshaders.iris.compat.dh.IrisLodRenderProgram.createProgram(IrisLodRenderProgram.java:165)
	at net.irisshaders.iris.compat.dh.DHCompatInternal.<init>(DHCompatInternal.java:75)
	at java.base/jdk.internal.reflect.DirectConstructorHandleAccessor.newInstance(DirectConstructorHandleAccessor.java:62)
	at java.base/java.lang.reflect.Constructor.newInstanceWithCaller(Constructor.java:502)
	at java.base/java.lang.reflect.Constructor.newInstance(Constructor.java:486)
	at net.irisshaders.iris.compat.dh.DHCompat.<init>(DHCompat.java:32)
	at net.irisshaders.iris.pipeline.IrisRenderingPipeline.<init>(IrisRenderingPipeline.java:384)
	at net.irisshaders.iris.Iris.createPipeline(Iris.java:616)
	at net.irisshaders.iris.pipeline.PipelineManager.preparePipeline(PipelineManager.java:33)
	at net.minecraft.class_310.handler$bge000$iris$resetPipeline(class_310.java:7702)
	at net.minecraft.class_310.method_18097(class_310.java)
	at net.minecraft.class_310.method_1481(class_310.java:2204)
	at net.minecraft.class_634.method_11120(class_634.java:430)
	at net.minecraft.class_2678.method_11567(class_2678.java:69)
	at net.minecraft.class_2678.method_11054(class_2678.java:17)
	at net.minecraft.class_2600.method_11072(class_2600.java:27)
	at net.minecraft.class_1255.method_18859(class_1255.java:162)
	at net.minecraft.class_4093.method_18859(class_4093.java:23)
	at net.minecraft.class_1255.method_16075(class_1255.java:136)
	at net.minecraft.class_1255.method_5383(class_1255.java:121)
	at net.minecraft.class_310.method_1523(class_310.java:1240)
	at net.minecraft.class_310.method_1514(class_310.java:882)
	at net.minecraft.client.main.Main.main(Main.java:256)
	at net.fabricmc.loader.impl.game.minecraft.MinecraftGameProvider.launch(MinecraftGameProvider.java:480)
	at net.fabricmc.loader.impl.launch.knot.Knot.launch(Knot.java:74)
	at net.fabricmc.loader.impl.launch.knot.KnotClient.main(KnotClient.java:23)
```

with the shader being disabled in the Overworld. The Pale Garden biome was introduced in Minecraft 1.21.4 so I figured this PR would fix the above. I've only tested it with Minecraft 1.21.1 though.