### PR TITLE
Linux AMD handheld lighting patch

### DIFF
--- a/shaders/lib/lighting/handlight.glsl
+++ b/shaders/lib/lighting/handlight.glsl
@@ -1,5 +1,5 @@
 void getHandLightColor(inout vec3 blockLighting, in vec3 normal, in vec3 pos) {
-    if ((heldItemId >= 1 || heldItemId2 >= 1) && (heldItemId <= 60 || heldItemId2 <= 60)) {
+    if ((heldItemId >= 1 && heldItemId <= 60) || (heldItemId2 >= 1 && heldItemId2 <= 60)) {
         float handlight = clamp((32.0 - length(pos) * 5.0) * 0.015, 0.0, 1.0);
 
         vec3 color1 = blocklightColorArray[min(max(heldItemId - 1, 0), blocklightColorArray.length() - 1)];

--- a/shaders/lib/lighting/handlight.glsl
+++ b/shaders/lib/lighting/handlight.glsl
@@ -2,8 +2,8 @@ void getHandLightColor(inout vec3 blockLighting, in vec3 normal, in vec3 pos) {
     if ((heldItemId >= 1 && heldItemId <= 60) || (heldItemId2 >= 1 && heldItemId2 <= 60)) {
         float handlight = clamp((32.0 - length(pos) * 5.0) * 0.015, 0.0, 1.0);
 
-        vec3 color1 = blocklightColorArray[min(max(heldItemId - 1, 0), blocklightColorArray.length() - 1)];
-        vec3 color2 = blocklightColorArray[min(max(heldItemId2 - 1, 0), blocklightColorArray.length() - 1)];
+        vec3 color1 = blocklightColorArray[clamp(heldItemId - 1, 0, blocklightColorArray.length() - 1)];
+        vec3 color2 = blocklightColorArray[clamp(heldItemId2 - 1, 0, blocklightColorArray.length() - 1)];
         vec3 handLightColor = mix(color1, color2, 0.5);
              handLightColor *= length(color1) + length(color2);
 

--- a/shaders/lib/lighting/handlight.glsl
+++ b/shaders/lib/lighting/handlight.glsl
@@ -2,8 +2,8 @@ void getHandLightColor(inout vec3 blockLighting, in vec3 normal, in vec3 pos) {
     if ((heldItemId >= 1 || heldItemId2 >= 1) && (heldItemId <= 60 || heldItemId2 <= 60)) {
         float handlight = clamp((32.0 - length(pos) * 5.0) * 0.015, 0.0, 1.0);
 
-        vec3 color1 = blocklightColorArray[max(heldItemId - 1, 0)];
-        vec3 color2 = blocklightColorArray[max(heldItemId2 - 1, 0)];
+        vec3 color1 = blocklightColorArray[min(max(heldItemId - 1, 0), blocklightColorArray.length() - 1)];
+        vec3 color2 = blocklightColorArray[min(max(heldItemId2 - 1, 0), blocklightColorArray.length() - 1)];
         vec3 handLightColor = mix(color1, color2, 0.5);
              handLightColor *= length(color1) + length(color2);
 

--- a/shaders/lib/lighting/handlight.glsl
+++ b/shaders/lib/lighting/handlight.glsl
@@ -2,8 +2,8 @@ void getHandLightColor(inout vec3 blockLighting, in vec3 normal, in vec3 pos) {
     if ((heldItemId >= 1 || heldItemId2 >= 1) && (heldItemId <= 60 || heldItemId2 <= 60)) {
         float handlight = clamp((32.0 - length(pos) * 5.0) * 0.015, 0.0, 1.0);
 
-        vec3 color1 = blocklightColorArray[heldItemId - 1];
-        vec3 color2 = blocklightColorArray[heldItemId2 - 1];
+        vec3 color1 = blocklightColorArray[max(heldItemId - 1, 0)];
+        vec3 color2 = blocklightColorArray[max(heldItemId2 - 1, 0)];
         vec3 handLightColor = mix(color1, color2, 0.5);
              handLightColor *= length(color1) + length(color2);
 


### PR DESCRIPTION
Fixed issue #56 by adding the clamp function to `blocklightColorArray[heldItemId - 1]` to avoid a possible [0,-1](https://shaders.properties/current/reference/uniforms/id/#helditemid) or >60 heldItemId from indexing into the array and returning a poison value that caused the visual glitch. 

Also fixed logic that allowed for two invalid ids to satisfy the if condition e.g. heldItemId=-1 and heldItemId2=61.

PS: I'm no shader developer this is just what I figured would work.