### PR TITLE
Add emission support for more modded lights.

### DIFF
--- a/shaders/block.properties
+++ b/shaders/block.properties
@@ -112,7 +112,14 @@ block.10005= \
 light wall_torch torch lantern campfire:lit=true fire furnace:lit=true blast_furnace:lit=true smoker:lit=true torchflower \
 supplementaries:wall_lantern \
 decorative_blocks:chandelier decorative_blocks:brazier \
-chipped:burning_coal_lantern chipped:checkered_iron_lantern chipped:iron_bowl_lantern chipped:wooden_cage_lantern chipped:wrought_iron_lantern chipped:big_lantern chipped:donut_lantern chipped:tall_lantern chipped:wide_lantern amendments:wall_lantern
+chipped:burning_coal_lantern chipped:checkered_iron_lantern chipped:iron_bowl_lantern chipped:wooden_cage_lantern chipped:wrought_iron_lantern chipped:big_lantern chipped:donut_lantern chipped:tall_lantern chipped:wide_lantern amendments:wall_lantern \
+mcwlights:oak_tiki_torch mcwlights:spruce_tiki_torch mcwlights:birch_tiki_torch mcwlights:jungle_tiki_torch mcwlights:acacia_tiki_torch mcwlights:dark_oak_tiki_torch mcwlights:crimson_tiki_torch mcwlights:warped_tiki_torch mcwlights:mangrove_tiki_torch mcwlights:bamboo_tiki_torch mcwlights:cherry_tiki_torch \
+mcwlights:striped_lantern mcwlights:covered_lantern mcwlights:chain_lantern mcwlights:tavern_lantern mcwlights:festive_lantern mcwlights:cross_lantern mcwlights:bell_lantern \
+mcwlights:wall_lantern mcwlights:striped_wall_lantern mcwlights:covered_wall_lantern mcwlights:chain_wall_lantern mcwlights:tavern_wall_lantern mcwlights:festive_wall_lantern mcwlights:cross_wall_lantern mcwlights:bell_wall_lantern \
+mcwlights:classic_street_lamp:lit=true mcwlights:double_street_lamp:lit=true mcwlights:framed_torch mcwlights:iron_framed_torch mcwlights:reinforced_torch mcwlights:rustic_torch mcwlights:upgraded_torch \
+ars_additions:golden_lantern ars_additions:sourcestone_lantern ars_additions:polished_sourcestone_lantern ars_additions:archwood_lantern \
+torchmaster:megatorch eternal_starlight:starlight_torchflower actuallyadditions:tiny_torch \
+supplementaries:stone_lamp supplementaries:blackstone_lamp supplementaries:deepslate_lamp
 
 #Soul Torch, Soul Lantern, Soul Campfire, Soul Fire
 block.10006= \
@@ -120,18 +127,24 @@ soul_wall_torch soul_torch soul_lantern soul_campfire:lit=true soul_fire \
 supplementaries:wall_soul_lantern \
 decorative_blocks:soul_chandelier decorative_blocks:soul_brazier \
 chipped:checkered_iron_soul_lantern chipped:iron_bowl_soul_lantern chipped:wooden_cage_soul_lantern chipped:big_soul_lantern chipped:donut_soul_lantern chipped:tall_soul_lantern chipped:wide_soul_lantern \
-create:blaze_burner:blaze=seething createaddition:liquid_blaze_burner:blaze=seething create_enchantment_industry:blaze_enchanter:blaze=seething
+create:blaze_burner:blaze=seething createaddition:liquid_blaze_burner:blaze=seething create_enchantment_industry:blaze_enchanter:blaze=seething \
+mcwlights:soul_oak_tiki_torch mcwlights:soul_spruce_tiki_torch mcwlights:soul_birch_tiki_torch mcwlights:soul_jungle_tiki_torch mcwlights:soul_acacia_tiki_torch mcwlights:soul_dark_oak_tiki_torch mcwlights:soul_crimson_tiki_torch mcwlights:soul_warped_tiki_torch mcwlights:soul_mangrove_tiki_torch mcwlights:soul_bamboo_tiki_torch mcwlights:soul_cherry_tiki_torch \
+mcwlights:soul_classic_street_lamp:lit=true mcwlights:soul_double_street_lamp:lit=true \
+integrateddynamics:menril_torch integrateddynamics:menril_torch_stone
 
 #End Rod
 block.10007= \
-end_rod
+end_rod \
+mcwlights:garden_light:lit=true \
+supplementaries:end_stone_lamp
 
 #Sea Lantern
 block.10008= \
 sea_lantern \
 chipped:broken_sea_lantern chipped:bulbed_sea_lantern chipped:cracked_sea_lantern chipped:double_inlayed_sea_lantern chipped:fancy_sea_lantern \
 chipped:framed_sea_lantern chipped:hived_sea_lantern chipped:inlayed_sea_lantern chipped:ornate_sea_lantern chipped:polished_sea_lantern chipped:reinforced_sea_lantern chipped:sea_lodestone_side \
-chipped:shimmering_sea_lantern chipped:smooth_sea_lantern chipped:special_sea_lantern chipped:thick_inlayed_sea_lantern chipped:tiled_sea_lantern_pillar 
+chipped:shimmering_sea_lantern chipped:smooth_sea_lantern chipped:special_sea_lantern chipped:thick_inlayed_sea_lantern chipped:tiled_sea_lantern_pillar \
+mcwlights:sea_lantern_slab
 
 #Glowstone
 block.10009= \
@@ -143,12 +156,14 @@ chipped:wither_engraved_glowstone \
 rechiseled:glowstone_brick_pattern rechiseled:glowstone_brick_pattern_connecting rechiseled:glowstone_brick_paving rechiseled:glowstone_brick_paving_connecting \
 rechiseled:glowstone_bricks rechiseled:glowstone_bricks_connecting rechiseled:glowstone_crushed rechiseled:glowstone_crushed_connecting rechiseled:glowstone_large_tiles rechiseled:glowstone_large_tiles_connecting \
 rechiseled:glowstone_rotated_bricks rechiseled:glowstone_rotated_bricks_connecting rechiseled:glowstone_small_tiles rechiseled:glowstone_small_tiles_connecting rechiseled:glowstone_smooth \
-rechiseled:glowstone_smooth_connecting rechiseled:glowstone_tiles rechiseled:glowstone_tiles_connecting
+rechiseled:glowstone_smooth_connecting rechiseled:glowstone_tiles rechiseled:glowstone_tiles_connecting \
+mcwlights:glowstone_slab
 
 #Shroomlight, Redstone Lamp, Copper Bulbs
 block.10010= \
 shroomlight redstone_lamp:lit=true waxed_copper_bulb:lit=true waxed_oxidized_copper_bulb:lit=true exposed_copper_bulb:lit=true waxed_exposed_copper_bulb:lit=true \
-oxidized_copper_bulb:lit=true_bulb:lit=true copper_bulb:lit=true weathered_copper_bulb:lit=true waxed_weathered_copper_bulb:lit=true
+oxidized_copper_bulb:lit=true_bulb:lit=true copper_bulb:lit=true weathered_copper_bulb:lit=true waxed_weathered_copper_bulb:lit=true \
+mcwlights:redstone_lamp_slab mcwlights:shroomlight_slab
 
 #Respawn Anchor
 block.10011= \
@@ -157,7 +172,8 @@ respawn_anchor:charges=1 respawn_anchor:charges=2 respawn_anchor:charges=3 respa
 #Lava
 block.10012= \
 lava lava_cauldron \
-create:blaze_burner:blaze=kindled createaddition:liquid_blaze_burner:blaze=kindled create_enchantment_industry:blaze_enchanter:blaze=kindled 
+create:blaze_burner:blaze=kindled createaddition:liquid_blaze_burner:blaze=kindled create_enchantment_industry:blaze_enchanter:blaze=kindled \
+mcwlights:lava_lamp
 
 #Cave Berries
 block.10013= \
@@ -263,98 +279,136 @@ enchanting_table
 block.10043= \
 red_candle:lit=true fire_coral fire_coral_fan \
 supplementaries:candle_holder_red:lit=true chipped:red_paper_lantern \
-chipped:small_red_soul_lantern 
+chipped:small_red_soul_lantern \
+mcwlights:red_lamp:lit=true mcwlights:red_ceiling_light:lit=true mcwlights:red_paper_lamp:lit=true \
+actuallyadditions:lamp_red:lit=true
 
 #Orange Candle
 block.10044= \
 orange_candle:lit=true \
 supplementaries:candle_holder_orange:lit=true \
-chipped:golden_paper_soul_lantern chipped:orange_paper_soul_lantern
+chipped:golden_paper_soul_lantern chipped:orange_paper_soul_lantern \
+mcwlights:orange_lamp:lit=true mcwlights:orange_ceiling_light:lit=true mcwlights:orange_paper_lamp:lit=true \
+actuallyadditions:lamp_orange:lit=true
 
 #Yellow Candle
 block.10045= \
 yellow_candle:lit=true horn_coral horn_coral_fan \
 supplementaries:candle_holder_yellow:lit=true \
-chipped:yellow_tube_lantern chipped:yellow_paper_soul_lantern
+chipped:yellow_tube_lantern chipped:yellow_paper_soul_lantern \
+mcwlights:yellow_lamp:lit=true mcwlights:yellow_ceiling_light:lit=true mcwlights:yellow_paper_lamp:lit=true \
+actuallyadditions:lamp_yellow:lit=true
 
 #Brown Candle
 block.10046= \
 brown_candle:lit=true \
-supplementaries:candle_holder_brown:lit=true
+supplementaries:candle_holder_brown:lit=true \
+mcwlights:brown_lamp:lit=true mcwlights:brown_ceiling_light:lit=true mcwlights:brown_paper_lamp:lit=true \
+actuallyadditions:lamp_brown:lit=true
 
 #Green Candle
 block.10047= \
 green_candle:lit=true \
 twilightforest:firefly_jar \
 supplementaries:candle_holder_green:lit=true \
-chipped:green_paper_lantern chipped:small_green_lantern 
+chipped:green_paper_lantern chipped:small_green_lantern \
+mcwlights:green_lamp:lit=true mcwlights:green_ceiling_light:lit=true mcwlights:green_paper_lamp:lit=true \
+actuallyadditions:lamp_green:lit=true
 
 #Lime Candle
 block.10048= \
 lime_candle:lit=true \
 supplementaries:candle_holder_lime:lit=true \
 chipped:lime_paper_soul_lantern \
-create:experience_block
+create:experience_block \
+mcwlights:lime_lamp:lit=true mcwlights:lime_ceiling_light:lit=true mcwlights:lime_paper_lamp:lit=true \
+actuallyadditions:lamp_lime:lit=true
 
 #Blue Candle
 block.10049= \
 blue_candle:lit=true tube_coral tube_coral_fan \
 supplementaries:candle_holder_blue:lit=true \
-chipped:dark_blue_paper_lantern chipped:blue_paper_soul_lantern 
+chipped:dark_blue_paper_lantern chipped:blue_paper_soul_lantern \
+mcwlights:blue_lamp:lit=true mcwlights:blue_ceiling_light:lit=true mcwlights:blue_paper_lamp:lit=true \
+actuallyadditions:lamp_blue:lit=true
 
 #Light blue Candle
 block.10050= \
 light_blue_candle:lit=true \
 supplementaries:candle_holder_light_blue:lit=true \
 chipped:blue_paper_lantern \
-ae2:energy_cell:fullness=3 ae2:energy_cell:fullness=4
+ae2:energy_cell:fullness=3 ae2:energy_cell:fullness=4 \
+mcwlights:light_blue_lamp:lit=true mcwlights:light_blue_ceiling_light:lit=true mcwlights:light_blue_paper_lamp:lit=true \
+actuallyadditions:lamp_light_blue:lit=true
 
 #Cyan Candle
 block.10051= \
 cyan_candle:lit=true \
 supplementaries:candle_holder_cyan:lit=true \
-chipped:blue_tube_soul_lantern
+chipped:blue_tube_soul_lantern \
+mcwlights:cyan_lamp:lit=true mcwlights:cyan_ceiling_light:lit=true mcwlights:cyan_paper_lamp:lit=true \
+actuallyadditions:lamp_cyan:lit=true
 
 #Purple Candle
 block.10052= \
 purple_candle:lit=true \
 supplementaries:candle_holder_purple:lit=true \
-chipped:ender_lantern chipped:purple_paper_lantern 
+chipped:ender_lantern chipped:purple_paper_lantern \
+mcwlights:purple_lamp:lit=true mcwlights:purple_ceiling_light:lit=true mcwlights:purple_paper_lamp:lit=true \
+actuallyadditions:lamp_purple:lit=true
 
 #Magenta Candle
 block.10053= \
 magenta_candle:lit=true bubble_coral bubble_coral_fan \
-supplementaries:candle_holder_magenta:lit=true
+supplementaries:candle_holder_magenta:lit=true \
+mcwlights:magenta_lamp:lit=true mcwlights:magenta_ceiling_light:lit=true mcwlights:magenta_paper_lamp:lit=true \
+actuallyadditions:lamp_magenta:lit=true
 
 #Pink Candle
 block.10054= \
 pink_candle:lit=true brain_coral brain_coral_fan \
-supplementaries:candle_holder_pink:lit=true
+supplementaries:candle_holder_pink:lit=true \
+mcwlights:pink_lamp:lit=true mcwlights:pink_ceiling_light:lit=true mcwlights:pink_paper_lamp:lit=true \
+actuallyadditions:lamp_pink:lit=true
 
 #Black Candle
 block.10055= \
 black_candle:lit=true \
-supplementaries:candle_holder_black:lit=true
+supplementaries:candle_holder_black:lit=true \
+mcwlights:black_lamp:lit=true mcwlights:black_ceiling_light:lit=true mcwlights:black_paper_lamp:lit=true \
+actuallyadditions:lamp_black:lit=true
 
 #White Candle
 block.10056= \
-white_candle:lit=true supplementaries:candle_holder_white:lit=true chipped:white_paper_lantern chorus_flower
+white_candle:lit=true supplementaries:candle_holder_white:lit=true chipped:white_paper_lantern chorus_flower \
+mcwlights:golden_low_candle_holder:lit=true mcwlights:golden_candle_holder:lit=true mcwlights:golden_wall_candle_holder:lit=true mcwlights:golden_double_candle_holder:lit=true mcwlights:golden_triple_candle_holder:lit=true mcwlights:golden_small_chandelier mcwlights:golden_chandelier \
+mcwlights:copper_low_candle_holder:lit=true mcwlights:copper_candle_holder:lit=true mcwlights:copper_wall_candle_holder:lit=true mcwlights:copper_double_candle_holder:lit=true mcwlights:copper_triple_candle_holder:lit=true mcwlights:copper_small_chandelier mcwlights:copper_chandelier \
+mcwlights:iron_low_candle_holder:lit=true mcwlights:iron_candle_holder:lit=true mcwlights:iron_wall_candle_holder:lit=true mcwlights:iron_double_candle_holder:lit=true mcwlights:iron_triple_candle_holder:lit=true mcwlights:iron_small_chandelier mcwlights:iron_chandelier
 
 #Gray Candle
 block.10057= \
 gray_candle:lit=true \
 supplementaries:candle_holder_gray:lit=true \
-chipped:gray_paper_soul_lantern
+chipped:gray_paper_soul_lantern \
+mcwlights:gray_lamp:lit=true mcwlights:gray_ceiling_light:lit=true mcwlights:gray_paper_lamp:lit=true \
+actuallyadditions:lamp_gray:lit=true
 
 #Light gray Candle
 block.10058= \
 light_gray_candle:lit=true \
-supplementaries:candle_holder_light_gray:lit=true
+supplementaries:candle_holder_light_gray:lit=true \
+mcwlights:light_gray_lamp:lit=true mcwlights:light_gray_ceiling_light:lit=true mcwlights:light_gray_paper_lamp:lit=true \
+actuallyadditions:lamp_light_gray:lit=true
 
 #Regular Candle
 block.10059= \
 candle:lit=true \
-supplementaries:candle_holder:lit=true
+supplementaries:candle_holder:lit=true \
+mcwlights:white_lamp:lit=true mcwlights:white_ceiling_light:lit=true mcwlights:white_paper_lamp:lit=true mcwlights:wall_lamp:lit=true mcwlights:square_wall_lamp:lit=true \
+mcwlights:cherry_ceiling_fan_light:lit=true mcwlights:oak_ceiling_fan_light:lit=true mcwlights:spruce_ceiling_fan_light:lit=true mcwlights:birch_ceiling_fan_light:lit=true \
+mcwlights:jungle_ceiling_fan_light:lit=true mcwlights:acacia_ceiling_fan_light:lit=true mcwlights:dark_oak_ceiling_fan_light:lit=true mcwlights:mangrove_ceiling_fan_light:lit=true \
+mcwlights:crimson_ceiling_fan_light:lit=true mcwlights:warped_ceiling_fan_light:lit=true \
+actuallyadditions:lamp_white:lit=true
 
 #Beacon
 block.10060= \


### PR DESCRIPTION
This PR adds emission support for a bunch of modded lights, mostly from [Macaw's Lights and Lamps](https://www.curseforge.com/minecraft/mc-mods/macaws-lights-and-lamps) and [Actually Additions](https://www.curseforge.com/minecraft/mc-mods/actually-additions), with a few others sprinkled in.