### PR TITLE
use voxy depth buffer for clipping volumetric clouds

### DIFF
--- a/shaders/lib/atmosphere/volumetricClouds.glsl
+++ b/shaders/lib/atmosphere/volumetricClouds.glsl
@@ -85,7 +85,7 @@ float CloudSample(vec2 coord, vec2 wind, float sampleAltitude, float thickness, 
 	float noiseCoverage = CloudCoverageDefault(sampleAltitude, amount);
 
 	float noise = CloudCombineDefault(noiseBase, noiseDetail, noiseCoverage, amount, density);
-	
+
 	return noise;
 }
 
@@ -98,7 +98,7 @@ float CloudSampleLowDetail(vec2 coord, vec2 wind, float sampleAltitude, float th
 	float noiseCoverage = CloudCoverageDefault(sampleAltitude, amount);
 
 	float noise = CloudCombineDefault(noiseBase, 0.0, noiseCoverage, amount, density);
-	
+
 	return noise;
 }
 
@@ -197,7 +197,7 @@ void computeVolumetricClouds(inout vec4 vc, in vec3 atmosphereColor, float z, fl
 
             vec3 rayIncrement = nWorldPos * rayLength;
             int sampleCount = int(min(planeDifference / rayLength, maxsampleCount) + 4);
-            
+
             vec3 startPos = cameraPosition + nearestPlane * nWorldPos;
             vec3 rayPos = startPos + rayIncrement * dither;
             float sampleTotalLength = nearestPlane + rayLength * dither;
@@ -289,7 +289,7 @@ void computeVolumetricClouds(inout vec4 vc, in vec3 atmosphereColor, float z, fl
 
             //Final color calculations
 			vec3 nSkyColor = normalize(skyColor + 0.0001);
-            vec3 cloudAmbientColor = fmix(atmosphereColor * atmosphereColor * 0.5, 
+            vec3 cloudAmbientColor = fmix(atmosphereColor * atmosphereColor * 0.5,
 									 fmix(ambientCol, atmosphereColor * nSkyColor * 0.5, 0.2 + timeBrightness * 0.3 + isSpecificBiome * 0.4),
 									 sunVisibility * (1.0 - wetness)) * (1.0 - scattering * 0.75);
             vec3 cloudLightColor = fmix(lightCol, lightCol * nSkyColor * 2.0, timeBrightnessSqrt * (0.5 - wetness * 0.5));
@@ -352,7 +352,7 @@ void getEndCloudSample(vec2 rayPos, vec2 wind, float attenuation, inout float no
 
 	float noiseCoverage = abs(attenuation - 0.125) * (attenuation > 0.125 ? 1.14 : 5.0);
 		  noiseCoverage *= noiseCoverage * 5.0;
-	
+
 	noise = mix(noiseBase, noiseDetail, 0.025 * int(0 < noiseBase)) * 22.0 - noiseCoverage;
 	noise = max(noise - END_DISK_AMOUNT - 1.0 + getProtoplanetaryDisk(rayPos), 0.0);
 	noise /= sqrt(noise * noise + 0.25);
@@ -438,7 +438,7 @@ void computeEndVolumetricClouds(inout vec4 vc, in vec3 atmosphereColor, float z,
 			float scattering = pow8(halfVoLSqrt);
 
 			vec3 rayPos = startPos + sampleStep * dither;
-			
+
 			float maxDepth = currentDepth;
 			float minimalNoise = 0.25 + dither * 0.25;
 			float sampleTotalLength = minDist + rayLength * dither;
@@ -449,10 +449,9 @@ void computeEndVolumetricClouds(inout vec4 vc, in vec3 atmosphereColor, float z,
 			for (int i = 0; i < sampleCount; i++, rayPos += sampleStep, sampleTotalLength += rayLength) {
 				if (0.99 < cloudAlpha || (length(viewPos) < sampleTotalLength && z < 1.0)) break;
 
-				#ifdef DISTANT_HORIZONS
+				#if defined DISTANT_HORIZONS
 				if ((lDhViewPos < sampleTotalLength && dhZ < 1.0)) break;
-				#endif
-				#ifdef VOXY
+				#elif defined VOXY
 				if ((lVxViewPos < sampleTotalLength && vxZ < 1.0)) break;
 				#endif
 


### PR DESCRIPTION
implemented identically to the existing DISTANT_HORIZONS functionality.

fixes #135 

<table>
<tr>
 <td>before
 <td>after
<tr>
 <td><img width="480" alt="image" src="https://github.com/user-attachments/assets/5afec9e0-a6cc-4299-9b30-f082fcd4f0c3" />
 <td><img width="480" alt="image" src="https://github.com/user-attachments/assets/f9393189-73fd-4fd2-8e29-844e5150dd52" />

<tr>
 <td><img width="480" alt="image" src="https://github.com/user-attachments/assets/917c9658-fae0-4487-bfe5-c15199ecd2c8" />
 <td><img width="480" alt="image" src="https://github.com/user-attachments/assets/7969b552-4095-408f-b04f-7b47fe1d1d17" />

</table>