### PR TITLE
modify depth for Voxy chunks in volumetrics

### DIFF
--- a/shaders/lib/atmosphere/volumetrics.glsl
+++ b/shaders/lib/atmosphere/volumetrics.glsl
@@ -68,7 +68,7 @@ void computeVolumetricLight(inout vec3 vl, in vec3 translucent, in float dither)
 	float linearZ0 = getLinearDepth(z0, gbufferProjectionInverse);
 	float linearZ1 = getLinearDepth(z1, gbufferProjectionInverse);
 
-    #ifdef DISTANT_HORIZONS
+    #if defined DISTANT_HORIZONS
 	float DHz0 = texture2D(dhDepthTex0, texCoord).r;
 	float DHz1 = texture2D(dhDepthTex1, texCoord).r;
 	float DHlinearZ0 = getLinearDepth(DHz0, dhProjectionInverse);
@@ -76,6 +76,14 @@ void computeVolumetricLight(inout vec3 vl, in vec3 translucent, in float dither)
 
     linearZ0 = min(linearZ0, DHlinearZ0);
     linearZ1 = min(linearZ1, DHlinearZ1);
+    #elif defined VOXY
+    float VXz0 = texture(vxDepthTexOpaque, texCoord).r;
+    float VXz1 = texture(vxDepthTexTrans, texCoord).r;
+    float VXlinearZ0 = getLinearDepth(VXz0, vxProjInv);
+    float VXlinearZ1 = getLinearDepth(VXz1, vxProjInv);
+
+    linearZ0 = min(linearZ0, VXlinearZ0);
+    linearZ1 = min(linearZ1, VXlinearZ1);
     #endif
 
 	//Positions & Common variables

--- a/shaders/programs/composite1.glsl
+++ b/shaders/programs/composite1.glsl
@@ -63,6 +63,11 @@ uniform sampler2D dhDepthTex0, dhDepthTex1;
 uniform mat4 dhProjectionInverse;
 #endif
 
+#ifdef VOXY
+uniform sampler2D vxDepthTexOpaque, vxDepthTexTrans;
+
+uniform mat4 vxProjInv;
+#endif
 uniform mat4 gbufferProjection;
 uniform mat4 gbufferProjectionInverse;
 uniform mat4 gbufferModelView;


### PR DESCRIPTION
This makes the change between real chunks and voxy chunks less jarring when fog is active.

Like my previous pr #136, it's a modification of an existing DH patch
<table>
<tr>
 <td>before
 <td>after
<tr>
 <td><img width="1920" height="1080" alt="Screenshot-2026-02-07-15:16:03" src="https://github.com/user-attachments/assets/101a2623-7cf5-49ee-8c02-62a40a81c3db" />
 <td><img width="1920" height="1079" alt="Screenshot-2026-02-07-15:16:30" src="https://github.com/user-attachments/assets/2f983e7d-0eeb-42df-afb7-00d67df8f69a" />

<tr>
 <td><img width="959" height="473" alt="Screenshot-2026-02-07-15:24:15" src="https://github.com/user-attachments/assets/c73deeb3-bb5d-40c6-b102-762304a8244c" />
 <td><img width="959" height="473" alt="Screenshot-2026-02-07-15:24:41" src="https://github.com/user-attachments/assets/14885c7c-b279-4d34-8c87-5a956c6fdec5" />

</table>