### PR TITLE
Fix shaders fail to load when disable ssao

### DIFF
--- a/shaders/programs/deferred1.glsl
+++ b/shaders/programs/deferred1.glsl
@@ -147,7 +147,7 @@ vec3 ToWorldVoxy(vec3 viewPos) {
 #include "/lib/util/ToWorld.glsl"
 #include "/lib/color/lightColor.glsl"
 
-#ifdef SSAO
+#if defined SSAO || defined SS_SHADOWS
 #include "/lib/lighting/ambientOcclusion.glsl"
 #endif
 


### PR DESCRIPTION
deferred1.fsh: deferred1.fsh: 0:238(24): error: no function with name 'GetLinearDepth' 0:238(10): error: operands to arithmetic operators must be numeric 